### PR TITLE
adds isolatedModules compatibility

### DIFF
--- a/.changeset/breezy-bottles-kneel.md
+++ b/.changeset/breezy-bottles-kneel.md
@@ -1,0 +1,5 @@
+---
+"react-polymorphic-forwardref": patch
+---
+
+adds isolatedModules compatibility

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,6 @@ import * as React from 'react';
 
 import { ForwardRefAsFunction } from './types';
 
-export { ForwardRefAsComponentPropsWithoutRef, ForwardRefAsComponentPropsWithRef } from './types';
+export type { ForwardRefAsComponentPropsWithoutRef, ForwardRefAsComponentPropsWithRef } from './types';
 
 export const forwardRefAs = React.forwardRef as ForwardRefAsFunction;


### PR DESCRIPTION
Importing the types is not allowed when `isolatedModules` is enabled on `tsconfig`. This can be resolved by exporting the types by using `export type ...` instead of `export ...`.